### PR TITLE
adhere to padded-blocks

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -40,7 +40,6 @@ exports.send = function (message, cb) {
     debug(message.text)
     cb(null)
   }
-
 }
 
 exports.notifyAdmin = function (subject, obj) {


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.