### PR TITLE
gitignore: include npm-debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bundle.js
 node_modules/
 out/
 db/
+npm-debug.log


### PR DESCRIPTION
Whenever `npm` finds errors, it outputs those messages to `npm-debug.log`. This file serves to help the debugging process when using `npm` but is not particularly relevant with regard to the files in this repository.

This PR appends `npm-debug.log` to the `.gitignore` file.